### PR TITLE
Allow empty string as prompt.

### DIFF
--- a/jqconsole.coffee
+++ b/jqconsole.coffee
@@ -152,7 +152,10 @@ class JQConsole
     @header = header or ''
 
     # The prompt label used by Prompt().
-    @prompt_label_main = prompt_label or DEFAULT_PROMPT_LABEL
+    if typeof(prompt_label) == 'string'
+       @prompt_label_main = prompt_label
+    else
+       @prompt_label_main = DEFAULT_PROMPT_LABEL
     @prompt_label_continue = ' \n' + (prompt_continue_label or
                                       DEFAULT_PROMPT_CONINUE_LABEL)
 


### PR DESCRIPTION
Providing '' as prompt didn't work as that value is or'ed with DEFAULT_PROMPT_LABEL, and the empty string behaves as false in OR.
