### PR TITLE
Fix cursor position after Clear

### DIFF
--- a/src/jqconsole.coffee
+++ b/src/jqconsole.coffee
@@ -629,7 +629,7 @@ class JQConsole
       .text ''
     # Bug in Chrome were the cursor's position is not recalculated
     @$prompt_cursor.detach()
-    @$prompt_after.before @$prompt_cursor
+    @$prompt_right.before @$prompt_cursor
 
   ###------------------------ Private Methods -------------------------------###
 


### PR DESCRIPTION
Cursor position is not set correctly after `Clear`.

Steps to reproduce the problem:
1. Type anything in the console.
2. Strike left arrow key for a couple of times.
3. `Ctrl+K` (or whatever clears the console).
4. The cursor moved to the end of the line. Arrow keys refuse to work.

This closes replit/repl.it#106.
