### PR TITLE
Keypress event (conditional) trigger

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -7,6 +7,14 @@ task 'watch', 'Build and watch the CoffeeScript source files', ->
   coffee.stdout.on 'data', log
   test.stdout.on 'data', log
 
+task 'compile', 'Compile to js library', ->
+  console.log 'compiling...'
+  exec 'coffee --compile --output lib/ src/', (err, res)->
+    if err
+      console.error 'failed with', err
+    else
+      console.log 'compile complete', res
+
 task 'build', 'Build minified file with uglify', ->
   console.log 'building...'
   exec 'uglifyjs -m -o jqconsole.min.js lib/jqconsole.js', (err, res)->

--- a/README.md
+++ b/README.md
@@ -328,7 +328,28 @@ operations. Takes no parameters.
   
         jqconsole.Reset()  
 
+###jqconsole.SetKeyPressPredicate
+Sets a callback that allows (if return value is true) or avoids (if return
+value is false) launching keypressed events from the `$(.jqconsole-user-text')`
+element.
 
+  * __function__ *predicate*: A function returning true or false. It accepts
+    the current user text and the newly added character (as string)
+  
+  Example:
+  ```javascript
+        jqconsole.SetKeyPressPredicate(function(current_text, new_char) {
+          input_text = current_text + new_char;
+          methods = propStartingWith(jqconsole, input_text);
+          return input_text.length > 2 && methods.length > 1;
+        });
+
+        $('.jqconsole-user-text').keypress(function (event) {
+          methods = propStartingWith(jqconsole, input_text);
+          jqconsole.Append($("<div>" + methods.join(",") + "</div>").css('background-color', '#333300'));
+        });
+   ```
+   
 ###jqconsole.GetColumn
 Returns the 0-based number of the column on which the cursor currently is.  
 Takes no parameters.  

--- a/demos/index.html
+++ b/demos/index.html
@@ -62,7 +62,17 @@
     <div id="console"></div>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js" type="text/javascript" charset="utf-8"></script>
     <script src="../lib/jqconsole.js"></script>
-       <script>
+    <script>
+      propStartingWith = function (obj, prefix) {
+        var res = [];
+        for(var m in obj) {
+          if(m.indexOf(prefix) === 0) {
+            res.push(m);
+          }
+        }
+        return res;
+      };
+
       $(function() {
         // Creating the console.
         var header = 'Welcome to JQConsole!\n' +
@@ -111,6 +121,17 @@
             return false;
           });
         };
+
+        jqconsole.SetKeyPressPredicate(function(current_text, new_char) {
+          input_text = current_text + new_char;
+          methods = propStartingWith(jqconsole, input_text);
+          return input_text.length > 2 && methods.length > 1;
+        });
+
+        $('.jqconsole-user-text').keypress(function (event) {
+          methods = propStartingWith(jqconsole, input_text);
+          jqconsole.Append($("<div>" + methods.join(",") + "</div>").css('background-color', '#333300'));
+        });
 
         // Initiate the first prompt.
         handler();

--- a/externs/jqconsole.ext.js
+++ b/externs/jqconsole.ext.js
@@ -82,5 +82,6 @@ JQConsole.prototype.IsDisabled = function() {};
 JQConsole.prototype.MoveToStart = function(all_lines) {};
 JQConsole.prototype.MoveToEnd = function(all_lines) {};
 JQConsole.prototype.Clear = function() {};
+JQConsole.prototype.SetKeyPressPredicate = function(predicate) {};
 
 /*---------------------- END Public Methods --------------------------- */

--- a/src/jqconsole.coffee
+++ b/src/jqconsole.coffee
@@ -265,6 +265,9 @@ class JQConsole
     @_SetupEvents()
     @Write @header, CLASS_HEADER
 
+    # Key pressed event predicate
+    @keypress_pred = (current_text, new_char) -> false
+
     # Save this instance to be accessed if lost.
     $(outer_container).data 'jqconsole', this
 
@@ -765,7 +768,7 @@ class JQConsole
       setTimeout handlePaste, 0
 
     # Actual key-by-key handling.
-    @$input_source.keypress @_HandleChar
+    @$input_source.keypress @_EventTriggeringHandleChar
     @$input_source.keydown @_HandleKey
     @$input_source.keydown @_CheckComposition
 
@@ -786,6 +789,26 @@ class JQConsole
       @$input_source.bind 'input', @_UpdateComposition
     else
       @$input_source.bind 'text', @_UpdateComposition
+
+  # Sets a callback that allows (if return value is true) or avoids (if return
+  # value is false) launching keypressed events.
+  # @arg predicate A function returning true or false. It should be a
+  #                function(current_text, new_char).
+  SetKeyPressPredicate: (predicate) ->
+    @keypress_pred = predicate
+
+  # Wraps _HandleChar in order to dispatch keypress events. The event is
+  # triggered iff the @keypress_pred returns true. This function also checks
+  # that the event can be processed normally (not isDefaultPrevented()).
+  #   @arg event: The jQuery keyboard Event object to handle.
+  _EventTriggeringHandleChar: (event) =>
+    # Pass current text and current key string to the predicate
+    if @keypress_pred @$prompt_left.text(), String.fromCharCode event.which
+      @$prompt_left.trigger event
+      if not event.isDefaultPrevented()
+        @_HandleChar event
+    else
+      @_HandleChar event
 
   # Handles a character key press.
   #   @arg event: The jQuery keyboard Event object to handle.

--- a/src/jqconsole.coffee
+++ b/src/jqconsole.coffee
@@ -34,6 +34,7 @@ CLASS_OLD_PROMPT = "#{CLASS_PREFIX}old-prompt"
 CLASS_INPUT = "#{CLASS_PREFIX}input"
 CLASS_OLD_INPUT = "#{CLASS_PREFIX}old-input"
 CLASS_BLURRED = "#{CLASS_PREFIX}blurred"
+CLASS_USER_TEXT = "#{CLASS_PREFIX}user-text"
 
 # Frequently used string literals
 E_KEYPRESS = 'keypress'
@@ -694,6 +695,7 @@ class JQConsole
     # (e.g. ">>> "), and the editable text to the left and right of the cursor.
     @$prompt_label = $(EMPTY_SPAN).appendTo @$prompt_current
     @$prompt_left = $(EMPTY_SPAN).appendTo @$prompt_current
+    @$prompt_left.attr 'class', CLASS_USER_TEXT
     @$prompt_right = $(EMPTY_SPAN).appendTo @$prompt_current
 
     # Needed for the CSS z-index on the cursor to work.


### PR DESCRIPTION
This is an implementation of the key press trigger.

It is conditional because if you push a function(current_text, new_char) with `SetKeyPressPredicate` and your function returns false (default), no event is triggered. This is done cause you might want to add logic, say, if the last word of the `current text + new_char` is a keyword then trigger, you can achieve it here.

It works quite nicely here  :+1:

Please let me know if I have been too prolific with the function names  :smile: 