### PR TITLE
Remove jqconsole-prompt-text from all but $prompt_left

### DIFF
--- a/externs/jqconsole.ext.js
+++ b/externs/jqconsole.ext.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Closure Compiler externs for jqconsole.js 2.11.0
+ * @fileoverview Closure Compiler externs for jqconsole.js 2.12.0
  * @see http://replit.github.io/jq-console
  * @externs
  * @author Andrea Richiardi
@@ -15,9 +15,11 @@
  * @param {?string|undefined} prompt_continue_label The label to
  *     show before continuation lines of the command prompt. Optional. Defaults
  *     to DEFAULT_PROMPT_CONINUE_LABEL.
+ * @param {?boolean|undefined} disable_auto_focus is a boolean indicating
+ *     whether we should disable the default auto-focus behavior.
  * @return {!JQConsole}
  */
-$.prototype.jqconsole = function(header, prompt_main, prompt_continue) {};
+$.prototype.jqconsole = function(header, prompt_main, prompt_continue, disable_auto_focus) {};
 
 /**
  * @constructor
@@ -26,15 +28,16 @@ $.prototype.jqconsole = function(header, prompt_main, prompt_continue) {};
  *     inserted.
  * @param {?string|undefined} header Text to print at the top of the console on
  * reset. Optional. Defaults to an empty string.
- * @param {(Element|jQuery|Document| Object.<string,
- *     (string|function(!jQuery.event=))>)=} prompt_label The label to show
+ * @param {?string|undefined} prompt_label The label to show
  *     before the command prompt. Optional. Defaults to DEFAULT_PROMPT_LABEL.
  * @param {?string|undefined} prompt_continue_label The label to
  *     show before continuation lines of the command prompt. Optional. Defaults
  *     to DEFAULT_PROMPT_CONINUE_LABEL.
+ * @param {?boolean|undefined} disable_auto_focus is a boolean indicating
+ *     whether we should disable the default auto-focus behavior.
  * @return {!JQConsole}
  */
-function JQConsole (outer_container, header, prompt_label, prompt_continue_label) {}
+function JQConsole (outer_container, header, prompt_label, prompt_continue_label, disable_auto_focus) {}
 
 /**
  * @constructor

--- a/src/jqconsole.coffee
+++ b/src/jqconsole.coffee
@@ -1122,7 +1122,7 @@ class JQConsole
     old_prompt = @_SelectPromptLabel not @$prompt_before.is EMPTY_SELECTOR
     $old_line = $(EMPTY_SPAN).appendTo @$prompt_before
     $old_line.append $(EMPTY_SPAN).text old_prompt
-    $old_line.append $(EMPTY_SPAN).text @$prompt_left.text()
+    $old_line.append $(EMPTY_SPAN).addClass(CLASS_PROMPT_TEXT).text @$prompt_left.text()
 
     @$prompt_label.text @_SelectPromptLabel true
     if indent and match = @$prompt_left.text().match /^\s+/

--- a/src/jqconsole.coffee
+++ b/src/jqconsole.coffee
@@ -706,9 +706,6 @@ class JQConsole
 
     # To indicate the prompt text (maybe used for highlighting etc)
     @$prompt_left.addClass(CLASS_PROMPT_TEXT)
-    @$prompt_right.addClass(CLASS_PROMPT_TEXT)
-    @$prompt_before.addClass(CLASS_PROMPT_TEXT)
-    @$prompt_after.addClass(CLASS_PROMPT_TEXT)
 
     # The cursor. A span containing a space that shades its following character.
     # If the font of the prompt is not monospace, the content should be set to


### PR DESCRIPTION
I opted for reverting, now only $prompt_left has `jqconsole-prompt-text`